### PR TITLE
Also act on /jira-epic slash command in the PR description

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,8 +39,8 @@ runs:
         fi
       shell: bash
 
-    - name: Check for /jira command in PR comments
-      if: github.event_name == 'issue_comment' && github.event.issue.pull_request != null
+    - name: Check for /jira command in PR comments and descriptions
+      if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request != null || github.event_name == 'pull_request_target' && github.event.action == 'edited' }}
       env:
         REPOSITORY: ${{ github.event.repository.full_name }}
         PR_NUMBER: ${{ github.event.issue.number }}
@@ -48,28 +48,50 @@ runs:
         PR_BODY: ${{ github.event.issue.body }}
         PR_AUTHOR: "${{ github.event.issue.user.login }}"
         COMMENT_BODY: ${{ github.event.comment.body }}
+        PR_URL: ${{github.event.issue.url}}
         GITHUB_TOKEN: ${{ inputs.token }}
         JIRA_TOKEN: ${{ inputs.jira_token }}
       run: |
         set -euo pipefail
-        if [[ ! "$COMMENT_BODY" =~ ^/jira-epic ]]; then
-          echo "No recognized slash command found."
+        if [[ "${{ github.event_name }}" == "issue_comment" ]]; then
+          echo "Event: New comment added to pull request."
+        elif [[ "${{ github.event.action }}" == "edited" ]]; then
+          echo "Event: Pull request description updated."
+          # Override variables based on the pull_request event type
+          PR_TITLE=$(echo "${{ github.event.pull_request.title }}")
+          PR_BODY=$(echo "${{ github.event.pull_request.body }}")
+          PR_AUTHOR=$(echo "${{ github.event.pull_request.user.login }}")
+          PR_URL=$(echo "${{github.event.pull_request.url}}")
+        fi
+
+        if [[ ! "$PR_BODY" =~ "/jira-epic" ]]; then
+          echo "⚪ No recognized slash command found."
           exit 0
         fi
 
         echo "🟢 Slash command '/jira-epic' detected"
 
-        # Exit if PR title contains a Jira ticket
+        # Exit if PR title or description contain a Jira ticket already
         echo "Bail if the pull request title already contains a Jira reference."
         set +e
         python3 "${{ github.action_path }}/pr_best_practices.py" --pr-title "$PR_TITLE"
         if [ "$?" == 0 ]; then
+          echo "⚪ The pull request title contains a Jira reference already, so we assume there's nothing to do."
+          exit 0;
+        fi
+
+        echo "Bail if the pull request body already contains a Jira reference."
+        python3 "${{ github.action_path }}/pr_best_practices.py" --pr-description-jira "$PR_BODY"
+        if [ "$?" == 2 ]; then
+          echo "⚪ The pull request description contains a Jira reference already, so we assume there's nothing to do."
           exit 0;
         fi
         set -e
-        echo "🟢 The pull request title doesn't contain a Jira reference yet. Continue."
 
-        EPIC_KEY=$(echo "$COMMENT_BODY" | sed -n 's/.*\b\([A-Z]\{2,\}-[0-9]\{1,\}\)\b.*/\1/p')
+        echo "🟢 The pull request title and description don't contain a Jira reference yet. Continue."
+
+        EPIC_KEY=$(python3 "${{ github.action_path }}/extract_jira_key.py" "$PR_BODY")
+        echo "Creating a new Task under the Epic $EPIC_KEY"
         JIRA_KEY=$(python3 "${{ github.action_path }}/jira_bot.py" \
           --token "$JIRA_TOKEN" \
           --summary "$PR_TITLE" \
@@ -78,11 +100,11 @@ runs:
           --assignee "$PR_AUTHOR" \
           --assignees-yaml "${{ github.action_path }}/assignees.yaml")
 
-        # Add a rocket reaction to the comment
-        # Edit the PR title and body with the JIRA key
+        # Add a rocket reaction if the trigger was a comment
+        # Update the PR title and body with the Jira key of the newly created Task
         python3 "${{ github.action_path }}/update_pr.py" \
           --comment-url "${{github.event.comment.url}}" \
-          --issue-url "${{github.event.issue.url}}" \
+          --issue-url "$PR_URL" \
           --github-token "$GITHUB_TOKEN" \
           --pr-title "$PR_TITLE" \
           --pr-body "$PR_BODY" \

--- a/action.yml
+++ b/action.yml
@@ -22,25 +22,71 @@ runs:
         pip install -r requirements.txt
       shell: bash
 
-    - name: Run all PR best practice checks
-      if: github.event_name == 'pull_request_target'
+    - name: Check for /jira command in PR descriptions
+      if: ${{ github.event_name == 'pull_request_target' }}
       env:
         REPOSITORY: ${{ github.event.repository.full_name }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
         PR_TITLE: ${{ github.event.pull_request.title }}
         PR_BODY: ${{ github.event.pull_request.body }}
+        PR_AUTHOR: "${{ github.event.pull_request.user.login }}"
+        PR_URL: ${{github.event.pull_request.url}}
         GITHUB_TOKEN: ${{ inputs.token }}
+        JIRA_TOKEN: ${{ inputs.jira_token }}
       run: |
+        set -euo pipefail
+
+        # Fail early if the PR description is empty
         python3 "${{ github.action_path }}/pr_best_practices.py" --pr-description "$PR_BODY"
+
+        if [[ ! "$PR_BODY" =~ "/jira-epic" ]]; then
+          echo "⚪ No recognized slash command found."
+          exit 0
+        fi
+
+        echo "🟢 Slash command '/jira-epic' detected"
+
+        # Exit if PR title or description contain a Jira ticket already and add best practice label
+        echo "Bail if the pull request title already contains a Jira reference."
         set +e
         python3 "${{ github.action_path }}/pr_best_practices.py" --pr-title "$PR_TITLE"
         if [ "$?" == 0 ]; then
           python3 "${{ github.action_path }}/pr_best_practices.py" --add-label --token "$GITHUB_TOKEN" --repository "$REPOSITORY" --pr-number "$PR_NUMBER"
+          echo "⚪ The pull request title contains a Jira reference already, so we assume there's nothing else to do."
+          exit 0;
         fi
+
+        echo "Bail if the pull request body already contains a Jira reference."
+        python3 "${{ github.action_path }}/pr_best_practices.py" --pr-description-jira "$PR_BODY"
+        if [ "$?" == 2 ]; then
+          echo "⚪ The pull request description contains a Jira reference already, so we assume there's nothing to do."
+          exit 0;
+        fi
+        set -e
+
+        echo "🟢 The pull request title and description don't contain a Jira reference yet. Continue."
+
+        EPIC_KEY=$(python3 "${{ github.action_path }}/extract_jira_key.py" "$PR_BODY")
+        echo "Creating a new Task under the Epic $EPIC_KEY"
+        JIRA_KEY=$(python3 "${{ github.action_path }}/jira_bot.py" \
+          --token "$JIRA_TOKEN" \
+          --summary "$PR_TITLE" \
+          --description "$PR_BODY" \
+          --epic-link "$EPIC_KEY" \
+          --assignee "$PR_AUTHOR" \
+          --assignees-yaml "${{ github.action_path }}/assignees.yaml")
+
+        # Update the PR title and body with the Jira key of the newly created Task
+        python3 "${{ github.action_path }}/update_pr.py" \
+          --issue-url "$PR_URL" \
+          --github-token "$GITHUB_TOKEN" \
+          --pr-title "$PR_TITLE" \
+          --pr-body "$PR_BODY" \
+          --jira-key "$JIRA_KEY"
       shell: bash
 
-    - name: Check for /jira command in PR comments and descriptions
-      if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request != null || github.event_name == 'pull_request_target' && github.event.action == 'edited' }}
+    - name: Check for /jira command in PR comments
+      if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request != null }}
       env:
         REPOSITORY: ${{ github.event.repository.full_name }}
         PR_NUMBER: ${{ github.event.issue.number }}
@@ -53,16 +99,6 @@ runs:
         JIRA_TOKEN: ${{ inputs.jira_token }}
       run: |
         set -euo pipefail
-        if [[ "${{ github.event_name }}" == "issue_comment" ]]; then
-          echo "Event: New comment added to pull request."
-        elif [[ "${{ github.event.action }}" == "edited" ]]; then
-          echo "Event: Pull request description updated."
-          # Override variables based on the pull_request event type
-          PR_TITLE=$(echo "${{ github.event.pull_request.title }}")
-          PR_BODY=$(echo "${{ github.event.pull_request.body }}")
-          PR_AUTHOR=$(echo "${{ github.event.pull_request.user.login }}")
-          PR_URL=$(echo "${{github.event.pull_request.url}}")
-        fi
 
         if [[ ! "$PR_BODY" =~ "/jira-epic" ]]; then
           echo "⚪ No recognized slash command found."

--- a/extract_jira_key.py
+++ b/extract_jira_key.py
@@ -1,0 +1,27 @@
+import sys
+import re
+
+def extract_jira_issue_key(text):
+    """
+    Extracts a Jira issue key from the input text following the /jira-epic pattern.
+    """
+    # regular expression to match the /jira-epic command and extract the issuekey
+    pattern = r"/jira-epic (\b[A-Z]+-\d+\b)"
+    # Search for the pattern in the text
+    match = re.search(pattern, text)
+    # Return the captured group if a match is found
+    return match.group(1) if match else None
+
+
+if __name__ == "__main__":
+    # Read input text from the command line argument
+    if len(sys.argv) > 1:
+        input_text = sys.argv[1]
+        # Extract and print the Jira issue key
+        jira_issue_key = extract_jira_issue_key(input_text)
+        if jira_issue_key:
+            print(jira_issue_key)
+        else:
+            sys.exit(0)
+    else:
+        print("Please provide the input text as an argument.")

--- a/jira_bot.py
+++ b/jira_bot.py
@@ -47,6 +47,7 @@ def is_epic_issue(jira, issue_key):
         if issue.fields.issuetype.name.lower() == 'epic':
             return True
         else:
+            print(f"The issue '{issue_key}' is not an Epic but a {issue.fields.issuetype.name}.", file=sys.stderr)
             return False
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/pr_best_practices.py
+++ b/pr_best_practices.py
@@ -50,7 +50,7 @@ def check_pr_description_not_empty(description):
 
 
 def check_pr_description_contains_jira(description):
-    regex = r"JIRA: \[[A-Z]*-[0-9]*\]\(https:\/\/issues.redhat.com\/browse\/[A-Z]*-[0-9]*\)"
+    regex = r"JIRA: \[[A-Z]+-[0-9]+\]\(https:\/\/issues.redhat.com\/browse\/[A-Z]+-[0-9]+\)"
     match = re.search(regex, description)
     if match:
         print(f"Found a Jira reference in the PR description: '{match.group(0)}'")

--- a/pr_best_practices.py
+++ b/pr_best_practices.py
@@ -49,6 +49,16 @@ def check_pr_description_not_empty(description):
         sys.exit(1)
 
 
+def check_pr_description_contains_jira(description):
+    regex = r"JIRA: \[[A-Z]*-[0-9]*\]\(https:\/\/issues.redhat.com\/browse\/[A-Z]*-[0-9]*\)"
+    match = re.search(regex, description)
+    if match:
+        print(f"Found a Jira reference in the PR description: '{match.group(0)}'")
+        sys.exit(2)
+    else:
+        print("The pull request description doesn't contain a Jira reference yet. Continue.")
+
+
 def add_best_practice_label(token, repository, pr_number):
     github_api_url = "https://api.github.com"
     url = f"{github_api_url}/repos/{repository}/issues/{pr_number}/labels"
@@ -72,6 +82,7 @@ if __name__ == "__main__":
     parser.add_argument("--pr-title", help="Check if PR title contains a Jira ticket")
     parser.add_argument("--check-commits", help="HEAD sha1 has of the pull request")
     parser.add_argument("--pr-description", help="Check if PR description is not empty")
+    parser.add_argument("--pr-description-jira", help="Check if PR description contains a Jira reference")
     parser.add_argument("--add-label", action="store_true", help="Add 'best-practice' label to the PR")
     parser.add_argument("--token", help="GitHub token")
     parser.add_argument("--repository", help="GitHub repository")
@@ -85,6 +96,8 @@ if __name__ == "__main__":
         check_commits_contain_jira(args.check_commits)
     if args.pr_description is not None:
         check_pr_description_not_empty(args.pr_description)
+    if args.pr_description_jira is not None:
+        check_pr_description_contains_jira(args.pr_description_jira)
     if args.add_label:
         if not (args.token and args.repository and args.pr_number):
             print("⛔ Token, repository, and PR number must be provided to add label.")

--- a/update_pr.py
+++ b/update_pr.py
@@ -11,19 +11,20 @@ def process_github_event(comment_url, issue_url, github_token, pr_title, pr_body
         "Authorization": f"Bearer {github_token}"
     }
 
-    # Add a rocket reaction to the comment
-    reaction_url = f"{comment_url}/reactions"
-    reaction_payload = {"content": "rocket"}
-    reaction_response = requests.post(
-        reaction_url,
-        headers=headers,
-        json=reaction_payload
-    )
+    if comment_url:
+        # Add a rocket reaction to the comment
+        reaction_url = f"{comment_url}/reactions"
+        reaction_payload = {"content": "rocket"}
+        reaction_response = requests.post(
+            reaction_url,
+            headers=headers,
+            json=reaction_payload
+        )
 
-    if reaction_response.status_code >= 200 and reaction_response.status_code < 300:
-        print("🟢 Rocket reaction added to the comment.")
-    else:
-        print(f"Failed to add reaction: {reaction_response.status_code} - {reaction_response.text}")
+        if reaction_response.status_code >= 200 and reaction_response.status_code < 300:
+            print("🟢 Rocket reaction added to the comment.")
+        else:
+            print(f"Failed to add reaction: {reaction_response.status_code} - {reaction_response.text}")
 
     # Update the pull request title and body
     new_title = f"{pr_title} ({jira_key})"
@@ -43,7 +44,7 @@ def process_github_event(comment_url, issue_url, github_token, pr_title, pr_body
 
 def main():
     parser = argparse.ArgumentParser(description="Process a GitHub event to add a reaction and update PR metadata.")
-    parser.add_argument("--comment-url", required=True, help="URL of the GitHub comment to react to.")
+    parser.add_argument("--comment-url", help="URL of the GitHub comment to react to.")
     parser.add_argument("--issue-url", required=True, help="URL of the GitHub issue or pull request to update.")
     parser.add_argument("--github-token", required=True, help="GitHub personal access token.")
     parser.add_argument("--pr-title", required=True, help="Current title of the pull request.")


### PR DESCRIPTION
This pull request does several things to also act on /jira-epic slash command in the PR description.

1. It adds a small script to extract the Jira key (convenience): `extract_jira_key.py`
2. It adds additional checks to the GitHub Action to prevent circular execution (i.e. creating yet another Task when e.g. dropping the Jira reference from the PR title)
3. It adds checks for the `/jira-epic` slash command for the pull request description to create a Jira Task this way.

One thing I'm not super-happy about is the overloading of environment variables, but I found no better way to deduplicate the code and act correctly on both events (which have different objects).

Also, some of the things noticed in the previous review are not addressed yet, e.g. the ugly `set +e`.

Finally, this change requires an update of the workflow file in each repository to enable this functionality. An example can be found here: https://github.com/osbuild/maintainer-tools/blob/main/.github/workflows/pr_best_practices.yml