### PR TITLE
jira_bot: Exit on Jira Task creation errors

### DIFF
--- a/jira_bot.py
+++ b/jira_bot.py
@@ -106,6 +106,7 @@ def create_jira_task(token, project_key, summary, description, issue_type, epic_
     # pylint: disable=broad-exception-caught
     except Exception as e:
         print(f"🔴 Failed to create task: {e}", file=sys.stderr)
+        sys.exit(1)
 
 
 def main():


### PR DESCRIPTION
Otherwise the pipeline continues and tries to update the PR description and title even though no ticket was created.