### PR TITLE
action: Fix /jira-epic pull request comment action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -100,7 +100,7 @@ runs:
       run: |
         set -euo pipefail
 
-        if [[ ! "$PR_BODY" =~ "/jira-epic" ]]; then
+        if [[ ! "$COMMENT_BODY" =~ "^/jira-epic" ]]; then
           echo "⚪ No recognized slash command found."
           exit 0
         fi


### PR DESCRIPTION
Previously, the check was looking at the pull request body/description as opposed to the comment body.
Also, add a leading ^ to the regular expression to make it more robust.