### PR TITLE
action: Extract Epic key from PR comment correctly

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -126,7 +126,7 @@ runs:
 
         echo "🟢 The pull request title and description don't contain a Jira reference yet. Continue."
 
-        EPIC_KEY=$(python3 "${{ github.action_path }}/extract_jira_key.py" "$PR_BODY")
+        EPIC_KEY=$(python3 "${{ github.action_path }}/extract_jira_key.py" "$COMMENT_BODY")
         echo "Creating a new Task under the Epic $EPIC_KEY"
         JIRA_KEY=$(python3 "${{ github.action_path }}/jira_bot.py" \
           --token "$JIRA_TOKEN" \


### PR DESCRIPTION
When splitting the code into two paths, this environment variable which was previously overloaded was left in place and of course cannot contain a Jira issue at this point in the code.