### PR TITLE
extract_jira_key.py: assure the epic to be returned uppercase

### DIFF
--- a/extract_jira_key.py
+++ b/extract_jira_key.py
@@ -10,7 +10,7 @@ def extract_jira_issue_key(text):
     # Search for the pattern in the text
     match = re.search(pattern, text, re.IGNORECASE)
     # Return the captured group if a match is found
-    return match.group(1) if match else None
+    return match.group(1).upper() if match else None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This might cause problems with the API if the epic key is not in uppercase.