### PR TITLE
action.yml: converting github issues to jira tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The slack integration, also contained in this repository is [documented below](#
 - **Check PR Description Is Not Empty**: Ensures that the pull request description is not empty.
 - **Add 'best-practice' Label to PR**: Automatically adds the 'best-practice' label to the pull request on GitHub.
 - **Creates a new Jira Ticket**: If the command `/jira-epic YOURJIRAKEY-1234` is detected in the **description** or a **comment** a Jira **Task** is created under the given Jira **Epic** "YOURJIRAKEY-1234"
+ - **Auto-create Jira Task for Issues**: When a new GitHub Issue is opened, a Jira Task can be created automatically if an epic is configured via the `new_issues_jira_epic` input. If unset, no task is created. The created Jira key is appended to the GitHub Issue title and body.
 
 ## Integration in your GitHub project
 
@@ -28,6 +29,8 @@ on:
     types: [opened, synchronize, reopened, edited]
   issue_comment:
     types: [created]
+  issues:
+    types: [opened]
 
 jobs:
   pr-best-practices:
@@ -38,6 +41,9 @@ jobs:
         with:
           token: ${{ secrets.YOUR_GITHUB_ACCESS_TOKEN }}
           jira_token: ${{ secrets.YOUR_JIRA_ACCESS_TOKEN }}
+          # Optional: create Jira tasks for newly opened GitHub Issues under this Epic
+          # If omitted, no task will be created for new issues
+          new_issues_jira_epic: HMS-5279
 ```
 
 ## Local use & Development

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   regex:
     description: "A custom regular expression for PR titles"
     required: false
+  new_issues_jira_epic:
+    description: "Optional Jira Epic key for auto-created tasks from newly opened GitHub Issues (e.g. 'HMS-1234'). If unset, no Jira task is created for new issues."
+    required: false
 
 runs:
   using: "composite"
@@ -144,5 +147,60 @@ runs:
           --github-token "$GITHUB_TOKEN" \
           --pr-title "$PR_TITLE" \
           --pr-body "$PR_BODY" \
+          --jira-key "$JIRA_KEY"
+      shell: bash
+
+    - name: Create Jira task for newly opened issues
+      if: ${{ github.event_name == 'issues' && github.event.action == 'opened' }}
+      env:
+        ISSUE_TITLE: ${{ github.event.issue.title }}
+        ISSUE_BODY: ${{ github.event.issue.body }}
+        ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+        ISSUE_API_URL: ${{ github.event.issue.url }}
+        ISSUE_HTML_URL: ${{ github.event.issue.html_url }}
+        GITHUB_TOKEN: ${{ inputs.token }}
+        JIRA_TOKEN: ${{ inputs.jira_token }}
+        NEW_ISSUES_JIRA_EPIC: ${{ inputs.new_issues_jira_epic }}
+      run: |
+        set -euo pipefail
+
+        EPIC_KEY="${NEW_ISSUES_JIRA_EPIC}"
+
+        if [[ -z "$EPIC_KEY" ]]; then
+          echo "⚪ 'new_issues_jira_epic' not set. Skipping Jira creation for new issues."
+          exit 0
+        fi
+
+        echo "Processing newly opened issue for Jira creation under epic $EPIC_KEY"
+
+        # Skip if title or body already contain a Jira reference
+        if python3 "${{ github.action_path }}/pr_best_practices.py" --pr-title "$ISSUE_TITLE"; then
+          echo "⚪ Issue title already contains a Jira reference. Skipping creation."
+          exit 0
+        fi
+        if ! python3 "${{ github.action_path }}/pr_best_practices.py" --pr-description-jira "$ISSUE_BODY"; then
+          echo "⚪ Issue body already contains a Jira reference. Skipping creation."
+          exit 0
+        fi
+
+        # Create Jira task
+        DESCRIPTION_WITH_LINK="$ISSUE_BODY
+
+        GitHub Issue: $ISSUE_HTML_URL"
+        echo "Creating a new Task under the Epic $EPIC_KEY"
+        JIRA_KEY=$(python3 "${{ github.action_path }}/jira_bot.py" \
+          --token "$JIRA_TOKEN" \
+          --summary "$ISSUE_TITLE" \
+          --description "$DESCRIPTION_WITH_LINK" \
+          --epic-link "$EPIC_KEY" \
+          --assignee "$ISSUE_AUTHOR" \
+          --assignees-yaml "${{ github.action_path }}/usermap.yaml")
+
+        # Update the GitHub issue title/body to include the Jira key and link
+        python3 "${{ github.action_path }}/update_pr.py" \
+          --issue-url "$ISSUE_API_URL" \
+          --github-token "$GITHUB_TOKEN" \
+          --pr-title "$ISSUE_TITLE" \
+          --pr-body "$ISSUE_BODY" \
           --jira-key "$JIRA_KEY"
       shell: bash


### PR DESCRIPTION
Adds a creation of Jira ticket when a new GitHub Issue is opened, defaults under epic `HMS-5279`. The created Jira key is appended to the GitHub Issue title and body.