### PR TITLE
jira_bot: Fix GDPR strict mode failure when assigning tickets

### DIFF
--- a/jira_bot.py
+++ b/jira_bot.py
@@ -13,24 +13,18 @@ DEFAULT_ISSUE_TYPE = os.getenv("DEFAULT_ISSUE_TYPE", "Task")
 DEFAULT_COMPONENT = os.getenv("DEFAULT_COMPONENT", "Image Builder")
 
 
-def get_jira_username(jira, github_nick):
+def get_jira_account_id(github_nick):
     """
-    Find the Jira username corresponding to a GitHub nickname.
-    Can also resolve E-Mail to Jira username
+    Return the Jira Cloud accountId for a GitHub nickname via usermap.yaml.
     """
     global assignee_mapping
 
-    user = assignee_mapping.github2jira(github_nick)
-    if not user:
-        print(f"🟠 Warning: No Jira username found for GitHub nickname '{github_nick}'.", file=sys.stderr)
+    account_id = assignee_mapping.github2jira(github_nick)
+    if not account_id:
+        print(f"🟠 Warning: No Jira account ID found for GitHub nickname '{github_nick}'.", file=sys.stderr)
         return None
 
-    resolved_user = jira.search_users(user)
-    if len(resolved_user) != 1:
-        print(f"🟠 Warning: Expected 1 user for '{github_nick}' but got {resolved_user}.", file=sys.stderr)
-        return None
-
-    return resolved_user[0].name
+    return account_id
 
 
 def is_epic_issue(jira, issue_key):
@@ -93,7 +87,7 @@ def create_jira_task(token, project_key, summary, description, issue_type, epic_
 
     # Add assignee if provided
     if assignee:
-        issue_dict['assignee'] = {'name': get_jira_username(jira, assignee)}
+        issue_dict['assignee'] = {'accountId': get_jira_account_id(assignee)}
 
     # Add component if provided
     if component:

--- a/test_jira_bot.py
+++ b/test_jira_bot.py
@@ -1,0 +1,106 @@
+"""Tests for jira_bot.py — verifies the GDPR strict mode fix.
+
+Reproduces the exact scenario from PR #4471: GitHub user 'tkoscieln'
+comments '/jira-epic HMS-10502', and jira_bot must resolve the assignee
+and build the correct issue_dict without calling jira.search_users().
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+import jira_bot
+from utils import UserMap
+
+
+USERMAP = "usermap.yaml"
+
+
+class TestGetJiraAccountId(unittest.TestCase):
+    """get_jira_account_id should return the accountId straight from
+    usermap.yaml, with no Jira API calls involved."""
+
+    def setUp(self):
+        jira_bot.assignee_mapping = UserMap(USERMAP)
+
+    def test_known_github_user_returns_account_id(self):
+        result = jira_bot.get_jira_account_id("tkoscieln")
+        self.assertEqual(result, "712020:afadf713-b939-4fc3-adfd-10bde24ab888")
+
+    def test_unknown_github_user_returns_none(self):
+        result = jira_bot.get_jira_account_id("nonexistent-user-12345")
+        self.assertIsNone(result)
+
+    def test_no_jira_api_call_is_made(self):
+        """The whole point of the fix: we must NOT call jira.search_users()."""
+        mock_jira = MagicMock()
+        # get_jira_account_id doesn't even accept a jira client anymore
+        result = jira_bot.get_jira_account_id("ochosi")
+        self.assertIsNotNone(result)
+        mock_jira.search_users.assert_not_called()
+
+
+class TestCreateJiraTaskAssigneeField(unittest.TestCase):
+    """create_jira_task must use {'accountId': ...} not {'name': ...}
+    when setting the assignee — Jira Cloud GDPR strict mode requires it."""
+
+    def setUp(self):
+        jira_bot.assignee_mapping = UserMap(USERMAP)
+
+    @patch("jira_bot.JIRA")
+    @patch("jira_bot.is_epic_issue", return_value=True)
+    def test_assignee_uses_account_id_field(self, _mock_epic, mock_jira_cls):
+        mock_jira = MagicMock()
+        mock_jira_cls.return_value = mock_jira
+        mock_issue = MagicMock()
+        mock_issue.key = "HMS-9999"
+        mock_jira.create_issue.return_value = mock_issue
+
+        jira_bot.create_jira_task(
+            token="fake-token",
+            project_key="HMS",
+            summary="Test PR title",
+            description="Test description",
+            issue_type="Task",
+            epic_link="HMS-10502",
+            component="Image Builder",
+            assignee="tkoscieln",
+            story_points=3,
+        )
+
+        call_kwargs = mock_jira.create_issue.call_args
+        fields = call_kwargs[1]["fields"] if "fields" in call_kwargs[1] else call_kwargs[0][0]
+        assignee = fields["assignee"]
+
+        self.assertIn("accountId", assignee,
+                       "Assignee must use 'accountId' for Jira Cloud GDPR mode")
+        self.assertNotIn("name", assignee,
+                         "Assignee must NOT use 'name' — rejected by GDPR strict mode")
+        self.assertEqual(assignee["accountId"],
+                         "712020:afadf713-b939-4fc3-adfd-10bde24ab888")
+
+    @patch("jira_bot.JIRA")
+    @patch("jira_bot.is_epic_issue", return_value=True)
+    def test_no_search_users_called(self, _mock_epic, mock_jira_cls):
+        """Ensures we never hit the deprecated search_users endpoint."""
+        mock_jira = MagicMock()
+        mock_jira_cls.return_value = mock_jira
+        mock_issue = MagicMock()
+        mock_issue.key = "HMS-9999"
+        mock_jira.create_issue.return_value = mock_issue
+
+        jira_bot.create_jira_task(
+            token="fake-token",
+            project_key="HMS",
+            summary="Test",
+            description="Test",
+            issue_type="Task",
+            epic_link="HMS-10502",
+            component="Image Builder",
+            assignee="tkoscieln",
+            story_points=3,
+        )
+
+        mock_jira.search_users.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`jira.search_users()` uses the deprecated 'username' query parameter which Jira Cloud rejects in GDPR strict mode (HTTP 400). Since `usermap.yaml` already contains Atlassian account IDs, use them directly and set 'accountId' instead of 'name' on the assignee field.