### PR TITLE
jira_bot: Switch to Basic Auth and fix Jira Cloud field mappings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,10 @@ inputs:
     description: "A GitHub token to add a label to the PR"
     required: true
   jira_token:
-    description: "A Jira token to create issues"
+    description: "A Jira API token to create issues"
+    required: true
+  jira_email:
+    description: "The Jira account email for the API token"
     required: true
   regex:
     description: "A custom regular expression for PR titles"
@@ -36,6 +39,7 @@ runs:
         PR_URL: ${{github.event.pull_request.url}}
         GITHUB_TOKEN: ${{ inputs.token }}
         JIRA_TOKEN: ${{ inputs.jira_token }}
+        JIRA_EMAIL: ${{ inputs.jira_email }}
       run: |
         set -euo pipefail
 
@@ -73,6 +77,7 @@ runs:
         echo "Creating a new Task under the Epic $EPIC_KEY"
         JIRA_KEY=$(python3 "${{ github.action_path }}/jira_bot.py" \
           --token "$JIRA_TOKEN" \
+          --email "$JIRA_EMAIL" \
           --summary "$PR_TITLE" \
           --description "$PR_BODY" \
           --epic-link "$EPIC_KEY" \
@@ -100,6 +105,7 @@ runs:
         PR_URL: ${{github.event.issue.url}}
         GITHUB_TOKEN: ${{ inputs.token }}
         JIRA_TOKEN: ${{ inputs.jira_token }}
+        JIRA_EMAIL: ${{ inputs.jira_email }}
       run: |
         set -euo pipefail
 
@@ -133,6 +139,7 @@ runs:
         echo "Creating a new Task under the Epic $EPIC_KEY"
         JIRA_KEY=$(python3 "${{ github.action_path }}/jira_bot.py" \
           --token "$JIRA_TOKEN" \
+          --email "$JIRA_EMAIL" \
           --summary "$PR_TITLE" \
           --description "$PR_BODY" \
           --epic-link "$EPIC_KEY" \
@@ -160,6 +167,7 @@ runs:
         ISSUE_HTML_URL: ${{ github.event.issue.html_url }}
         GITHUB_TOKEN: ${{ inputs.token }}
         JIRA_TOKEN: ${{ inputs.jira_token }}
+        JIRA_EMAIL: ${{ inputs.jira_email }}
         NEW_ISSUES_JIRA_EPIC: ${{ inputs.new_issues_jira_epic }}
       run: |
         set -euo pipefail
@@ -190,6 +198,7 @@ runs:
         echo "Creating a new Task under the Epic $EPIC_KEY"
         JIRA_KEY=$(python3 "${{ github.action_path }}/jira_bot.py" \
           --token "$JIRA_TOKEN" \
+          --email "$JIRA_EMAIL" \
           --summary "$ISSUE_TITLE" \
           --description "$DESCRIPTION_WITH_LINK" \
           --epic-link "$EPIC_KEY" \

--- a/jira_bot.md
+++ b/jira_bot.md
@@ -1,7 +1,8 @@
 # Usage
 ```
-       jira_bot.py [-h] --token TOKEN [--project-key PROJECT_KEY] --summary
-                   SUMMARY --description DESCRIPTION [--issuetype ISSUETYPE]
+       jira_bot.py [-h] --token TOKEN --email EMAIL
+                   [--project-key PROJECT_KEY] --summary SUMMARY
+                   --description DESCRIPTION [--issuetype ISSUETYPE]
                    [--assignee ASSIGNEE] [--story-points STORY_POINTS]
                    --epic-link EPIC_LINK [--component COMPONENT]
                    [--assignees-yaml ASSIGNEES_YAML] [--help-md]
@@ -11,7 +12,8 @@ Create a Jira task.
 # Options
 ```
   -h, --help            show this help message and exit
-  --token TOKEN         The Jira personal access token
+  --token TOKEN         The Jira API token
+  --email EMAIL         The Jira account email
   --project-key PROJECT_KEY
                         The Jira project id (optional, default: HMS)
   --summary SUMMARY     The summary of the task.

--- a/jira_bot.py
+++ b/jira_bot.py
@@ -7,7 +7,7 @@ import sys
 from jira import JIRA
 from utils import UserMap, format_help_as_md
 
-JIRA_SERVER = os.getenv("JIRA_SERVER", "https://issues.redhat.com")
+JIRA_SERVER = os.getenv("JIRA_SERVER", "https://redhat.atlassian.net")
 DEFAULT_PROJECT_KEY = os.getenv("DEFAULT_PROJECT_KEY", "HMS")
 DEFAULT_ISSUE_TYPE = os.getenv("DEFAULT_ISSUE_TYPE", "Task")
 DEFAULT_COMPONENT = os.getenv("DEFAULT_COMPONENT", "Image Builder")
@@ -49,19 +49,16 @@ def is_epic_issue(jira, issue_key):
 
 
 # pylint: disable=too-many-arguments
-def create_jira_task(token, project_key, summary, description, issue_type, epic_link, component, assignee, story_points):
+def create_jira_task(token, email, project_key, summary,
+                     description, issue_type, epic_link, component,
+                     assignee, story_points):
     """
     create_jira_task creates a jira issue with the given parameter
     """
-    options = {
-        'server': JIRA_SERVER,
-        'headers': {
-            'Authorization': f'Bearer {token}'
-        }
-    }
     try:
-        jira = JIRA(options=options)
-        print("Connected to Jira successfully using a personal access token.", file=sys.stderr)
+        jira = JIRA(server=JIRA_SERVER,
+                    basic_auth=(email, token))
+        print(f"Connected to Jira ({JIRA_SERVER}).", file=sys.stderr)
     # pylint: disable=broad-exception-caught
     except Exception as e:
         print(f"🔴 Failed to connect to Jira: {e}", file=sys.stderr)
@@ -78,12 +75,12 @@ def create_jira_task(token, project_key, summary, description, issue_type, epic_
         'summary': summary,
         'description': description,
         'issuetype': {'name': issue_type},
-        'customfield_12310243': story_points,
+        'customfield_10028': story_points,
     }
 
     # Add epic link if provided
     if epic_link:
-        issue_dict['customfield_12311140'] = epic_link
+        issue_dict['parent'] = {'key': epic_link}
 
     # Add assignee if provided
     if assignee:
@@ -110,7 +107,9 @@ def main():
     # Parse command-line arguments
     parser = argparse.ArgumentParser(description="Create a Jira task.")
     parser.add_argument('--token', required=True,
-                        help="The Jira personal access token")
+                        help="The Jira API token")
+    parser.add_argument('--email', required=True,
+                        help="The Jira account email")
     parser.add_argument('--project-key', default=DEFAULT_PROJECT_KEY,
                         help=f"The Jira project id (optional, default: {DEFAULT_PROJECT_KEY})")
     parser.add_argument('--summary', required=True,
@@ -143,6 +142,7 @@ def main():
     # Call the task creation function with parsed arguments
     create_jira_task(
         token=args.token,
+        email=args.email,
         project_key=args.project_key,
         summary=args.summary,
         description=args.description,

--- a/update_pr.md
+++ b/update_pr.md
@@ -1,8 +1,8 @@
 # Usage
 ```
        update_pr.py [-h] [--comment-url COMMENT_URL] --issue-url ISSUE_URL
-                    --github-token GITHUB_TOKEN --pr-title PR_TITLE --pr-body
-                    PR_BODY --jira-key JIRA_KEY [--help-md]
+                    --github-token GITHUB_TOKEN --pr-title PR_TITLE
+                    --pr-body PR_BODY --jira-key JIRA_KEY [--help-md]
 ```
 Process a GitHub event to add a reaction and update PR metadata.
 


### PR DESCRIPTION
The Bearer token via the issues.redhat.com proxy caused 301 redirects that converted POST to GET, breaking create_issue(). Switch to Basic Auth (email + API token) against redhat.atlassian.net directly.

Also fix the field IDs for Jira Cloud:
- Epic link: use standard `parent` field instead of customfield_12311140
- Story points: use customfield_10028 instead of customfield_12310243